### PR TITLE
Some changes

### DIFF
--- a/Test/alpha/CMakeLists.txt
+++ b/Test/alpha/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.26)
+cmake_minimum_required(VERSION 3.15)
+project(myalpha LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_STANDARD 17)
@@ -13,3 +14,5 @@ target_include_directories(alpha
 add_subdirectory(alpha1/alpha1_1)
 add_subdirectory(alpha1/alpha1_2)
 add_subdirectory(alpha2)
+
+install(TARGETS alpha alpha1_1 alpha1_2 alpha2)

--- a/Test/alpha/alpha1/alpha1_1/CMakeLists.txt
+++ b/Test/alpha/alpha1/alpha1_1/CMakeLists.txt
@@ -14,7 +14,7 @@ target_include_directories(${PROJECT_NAME}
 	PUBLIC
 		${CMAKE_CURRENT_SOURCE_DIR}/include
 )
-
+set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/include/alpha/alpha1_1/alpha1_1.hpp")
 target_link_libraries(${PROJECT_NAME}
 	PUBLIC
 		alpha

--- a/Test/alpha/alpha1/alpha1_1/include/alpha/alpha1_1/alpha1_1.hpp
+++ b/Test/alpha/alpha1/alpha1_1/include/alpha/alpha1_1/alpha1_1.hpp
@@ -1,3 +1,9 @@
 #pragma once
 
-void	alpha1_1();
+#ifdef _WIN32
+  #define ALPHA1_1_EXPORT __declspec(dllexport)
+#else
+  #define ALPHA1_1_EXPORT
+#endif
+
+ALPHA1_1_EXPORT void	alpha1_1();

--- a/Test/alpha/alpha1/alpha1_2/CMakeLists.txt
+++ b/Test/alpha/alpha1/alpha1_2/CMakeLists.txt
@@ -13,6 +13,8 @@ target_include_directories(${PROJECT_NAME}
 		${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
+set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/include/alpha/alpha1_2/alpha1_2.hpp")
+
 target_link_libraries(${PROJECT_NAME}
 	PUBLIC
 		alpha

--- a/Test/alpha/alpha1/alpha1_2/include/alpha/alpha1_2/alpha1_2.hpp
+++ b/Test/alpha/alpha1/alpha1_2/include/alpha/alpha1_2/alpha1_2.hpp
@@ -1,3 +1,9 @@
 #pragma once
 
-void alpha1_2();
+#ifdef _WIN32
+  #define ALPHA1_2_EXPORT __declspec(dllexport)
+#else
+  #define ALPHA1_2_EXPORT
+#endif
+
+ALPHA1_2_EXPORT void alpha1_2();

--- a/Test/alpha/alpha2/CMakeLists.txt
+++ b/Test/alpha/alpha2/CMakeLists.txt
@@ -13,6 +13,7 @@ target_include_directories(${PROJECT_NAME}
 		${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
+
 target_link_libraries(${PROJECT_NAME}
 	PUBLIC
 		alpha1_1

--- a/Test/alpha/alpha2/include/alpha/alpha2/alpha2.hpp
+++ b/Test/alpha/alpha2/include/alpha/alpha2/alpha2.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#ifdef _WIN32
+  #define ALPHA2_EXPORT __declspec(dllexport)
+#else
+  #define ALPHA2_EXPORT
+#endif
+
+ALPHA2_EXPORT void	alpha2();

--- a/Test/alpha/test_package/CMakeLists.txt
+++ b/Test/alpha/test_package/CMakeLists.txt
@@ -1,22 +1,17 @@
-set(PROJECT_NAME beta)
+set(PROJECT_NAME example)
 cmake_minimum_required(VERSION 3.15)
 project(${PROJECT_NAME} LANGUAGES CXX)
 
 find_package(alpha)
 
-add_library(${PROJECT_NAME} SHARED)
+add_executable(${PROJECT_NAME})
 
 target_sources(${PROJECT_NAME}
 	PRIVATE
-		beta.cpp
-)
-
-target_include_directories(${PROJECT_NAME}
-	PUBLIC
-		${CMAKE_CURRENT_SOURCE_DIR}/include
+		example.cpp
 )
 
 target_link_libraries(${PROJECT_NAME}
 	PUBLIC
-		alpha::alpha1_1
+		alpha::alpha1_2
 )

--- a/Test/alpha/test_package/conanfile.py
+++ b/Test/alpha/test_package/conanfile.py
@@ -1,0 +1,25 @@
+import os
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class Pkg(ConanFile):
+
+	# Binary configuration
+	settings = "os", "compiler", "build_type", "arch"
+	generators = "CMakeDeps", "CMakeToolchain"
+
+	def requirements(self):
+		self.requires(self.tested_reference_str)
+
+	def layout(self):
+		cmake_layout(self)
+
+	def build(self):
+		cmake = CMake(self)
+		cmake.configure()
+		cmake.build()
+
+	def test(self):
+		cmd = os.path.join(self.cpp.build.bindir, "example")
+		self.run(cmd, env="conanrun")

--- a/Test/alpha/test_package/example.cpp
+++ b/Test/alpha/test_package/example.cpp
@@ -1,0 +1,7 @@
+#include "alpha1_2.hpp"
+
+int	main()
+{
+	alpha1_2();
+	return 0;
+}

--- a/build.py
+++ b/build.py
@@ -1,0 +1,9 @@
+import os
+
+def run(cmd):
+    ret = os.system(cmd)
+    if ret != 0:
+        raise Exception(f"Failed CMD: {cmd}")
+
+
+run("conan create Test/alpha --build=missing")


### PR DESCRIPTION
- Made it portable, tested in Windows and Linux. Added necessary EXPORT definitions for WIn
- Only the ``alpha`` package at this stage
- Added ``test_package`` to ``alpha``
- Adding missing general ``project(myalpha LANGUAGES CXX)``
- Adding missing exporting of headers
- Just focused on the ``conan create`` at this stage, not yet on ``editable``

To reproduce:
```
python build.py
```

See review for more details